### PR TITLE
Revert "pager: do not change workspace size from size_allocate"

### DIFF
--- a/libwnck/pager.c
+++ b/libwnck/pager.c
@@ -135,6 +135,8 @@ static void     wnck_pager_get_preferred_height_for_width (GtkWidget *widget,
                                                            int        width,
                                                            int       *minimum_height,
                                                            int       *natural_height);
+static void     wnck_pager_size_allocate (GtkWidget        *widget,
+                                          GtkAllocation    *allocation);
 static gboolean wnck_pager_draw          (GtkWidget        *widget,
                                           cairo_t          *cr);
 static gboolean wnck_pager_button_press  (GtkWidget        *widget,
@@ -323,6 +325,7 @@ wnck_pager_class_init (WnckPagerClass *klass)
   widget_class->get_preferred_width_for_height = wnck_pager_get_preferred_width_for_height;
   widget_class->get_preferred_height = wnck_pager_get_preferred_height;
   widget_class->get_preferred_height_for_width = wnck_pager_get_preferred_height_for_width;
+  widget_class->size_allocate = wnck_pager_size_allocate;
   widget_class->draw = wnck_pager_draw;
   widget_class->button_press_event = wnck_pager_button_press;
   widget_class->button_release_event = wnck_pager_button_release;
@@ -766,6 +769,62 @@ wnck_pager_get_preferred_height_for_width (GtkWidget *widget,
 
   height += workspace_height * spaces_per_row + (spaces_per_row - 1);
   *natural_height = *minimum_height = MAX (height, 0);
+}
+
+static gboolean
+_wnck_pager_queue_resize (gpointer data)
+{
+  gtk_widget_queue_resize (GTK_WIDGET (data));
+  return FALSE;
+}
+
+static void
+wnck_pager_size_allocate (GtkWidget      *widget,
+                          GtkAllocation  *allocation)
+{
+  WnckPager *pager;
+  int workspace_size;
+  GtkBorder padding;
+  int width;
+  int height;
+
+  pager = WNCK_PAGER (widget);
+
+  width = allocation->width;
+  height = allocation->height;
+
+  _wnck_pager_get_padding (pager, &padding);
+  width  -= padding.left + padding.right;
+  height -= padding.top + padding.bottom;
+
+  g_assert (pager->priv->n_rows > 0);
+
+  if (pager->priv->orientation == GTK_ORIENTATION_VERTICAL)
+    {
+      if (pager->priv->show_all_workspaces)
+	workspace_size = (width - (pager->priv->n_rows - 1))  / pager->priv->n_rows;
+      else
+	workspace_size = width;
+    }
+  else
+    {
+      if (pager->priv->show_all_workspaces)
+	workspace_size = (height - (pager->priv->n_rows - 1))/ pager->priv->n_rows;
+      else
+	workspace_size = height;
+    }
+
+  workspace_size = MAX (workspace_size, 1);
+
+  if (workspace_size != pager->priv->workspace_size)
+    {
+      pager->priv->workspace_size = workspace_size;
+      g_idle_add (_wnck_pager_queue_resize, pager);
+      return;
+    }
+
+  GTK_WIDGET_CLASS (wnck_pager_parent_class)->size_allocate (widget,
+                                                             allocation);
 }
 
 static void


### PR DESCRIPTION
This reverts commit 3456b747b6381f17d48629dd8fdd4d511e739b10. 
And fixes broken workspace-switcher aspect ratio

bug report: https://github.com/mate-desktop/mate-panel/issues/1230